### PR TITLE
feat: implement Phase 1 smart school ranking based on student profile

### DIFF
--- a/app/(student)/discover/page.tsx
+++ b/app/(student)/discover/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/ui/Button';
 import StripeRule from '@/components/ui/StripeRule';
 import { getSchools } from '@/lib/supabase/database';
 import { upsertMatch } from '@/lib/supabase/database';
+import { rankSchoolsForStudent } from '@/lib/supabase/schoolRanking';
 import { useAuth } from '@/hooks/useAuth';
 import type { SchoolRow } from '@/lib/supabase/types';
 
@@ -320,14 +321,23 @@ export default function DiscoverPage() {
   const reels: Reel[] = [];
   const articles: Article[] = [];
 
-  // ── Load real schools from Supabase ──────────────────────────────────────
+  // ── Load real schools from Supabase with smart ranking ──────────────────────
   useEffect(() => {
-    getSchools().then((data) => {
-      // Reverse so first school shows on top of TinderCard stack
-      setSchools([...data].reverse());
-      setLoadingSchools(false);
+    getSchools().then((allSchools) => {
+      // If user is logged in and has a profile, rank schools by relevance
+      if (user?.id && user?.profile) {
+        rankSchoolsForStudent(user.id, user.profile, allSchools).then((rankedSchools) => {
+          // Reverse so first school shows on top of TinderCard stack
+          setSchools([...rankedSchools].reverse());
+          setLoadingSchools(false);
+        });
+      } else {
+        // Fallback: show schools in default order if not logged in or no profile
+        setSchools([...allSchools].reverse());
+        setLoadingSchools(false);
+      }
     });
-  }, []);
+  }, [user?.id, user?.profile]);
 
   const showToast = (msg: string) => {
     setToast(msg);

--- a/lib/supabase/database.ts
+++ b/lib/supabase/database.ts
@@ -122,6 +122,15 @@ export async function getMatchesForStudent(studentId: string): Promise<MatchRow[
   return data ?? []
 }
 
+export async function getStudentRightSwipes(studentId: string): Promise<string[]> {
+  const { data } = await getSupabase()
+    .from('matches')
+    .select('school_id')
+    .eq('student_id', studentId)
+    .eq('student_swipe', 'right')
+  return data?.map((m) => m.school_id) ?? []
+}
+
 // ─── Groups ───────────────────────────────────────────────────────────────────
 
 export async function getGroupByInviteLink(token: string): Promise<GroupRow | null> {

--- a/lib/supabase/schoolRanking.ts
+++ b/lib/supabase/schoolRanking.ts
@@ -1,0 +1,134 @@
+import type { SchoolRow, UserRow } from '@/lib/supabase/types'
+import { getSupabase } from '@/lib/supabase/client'
+
+/**
+ * Score a single school based on how well it matches the student's profile
+ *
+ * Scoring breakdown:
+ * - Field overlap (60% weight): How many of the student's interests match the school's target fields
+ * - Education level match (20% weight): Does the school accept the student's education level?
+ * - Region match (20% weight): Does the school recruit from the student's region?
+ */
+function scoreSchoolForStudent(school: SchoolRow, userProfile: UserRow): number {
+  let score = 0
+
+  // 1. Field overlap (60% weight, max 60 points)
+  if (userProfile.education_branches && userProfile.education_branches.length > 0 && school.target_fields && school.target_fields.length > 0) {
+    const overlap = userProfile.education_branches.filter((branch) =>
+      school.target_fields.includes(branch)
+    ).length
+    const fieldScore = (overlap / userProfile.education_branches.length) * 60
+    score += fieldScore
+  }
+
+  // 2. Education level match (20% weight, 20 points if match)
+  if (userProfile.education_level && school.target_levels && school.target_levels.includes(userProfile.education_level)) {
+    score += 20
+  }
+
+  // 3. Region match (20% weight, 20 points if match)
+  if (userProfile.postal_code && school.target_regions && school.target_regions.length > 0) {
+    // Extract region from postal code (first 2 digits = French region code)
+    const regionCode = userProfile.postal_code.substring(0, 2)
+    const matchesRegion = school.target_regions.some(
+      (region) => region.includes(regionCode) || region === 'International' || region === 'National'
+    )
+    if (matchesRegion) {
+      score += 20
+    }
+  }
+
+  return score
+}
+
+/**
+ * Load schools that the student has previously swiped right on
+ * Used to identify categories the student is interested in
+ */
+async function getStudentRightSwipedSchools(studentId: string): Promise<SchoolRow[]> {
+  const { data: matches } = await getSupabase()
+    .from('matches')
+    .select('school_id')
+    .eq('student_id', studentId)
+    .eq('student_swipe', 'right')
+
+  if (!matches || matches.length === 0) {
+    return []
+  }
+
+  const schoolIds = matches.map((m) => m.school_id)
+
+  const { data: schools } = await getSupabase()
+    .from('schools')
+    .select('*')
+    .in('id', schoolIds)
+
+  return schools ?? []
+}
+
+/**
+ * Apply a boost to schools that are similar to ones the student has already swiped right on
+ * This teaches the algorithm: "show me more schools like the ones I liked"
+ */
+function applyBehavioralBoost(school: SchoolRow, rightSwipedSchools: SchoolRow[]): number {
+  let boost = 0
+
+  // Find schools the student swiped right on
+  for (const likedSchool of rightSwipedSchools) {
+    // Boost if both schools are in the same fields
+    const fieldOverlap = school.target_fields.filter((field) =>
+      likedSchool.target_fields.includes(field)
+    ).length
+
+    if (fieldOverlap > 0) {
+      boost += fieldOverlap * 10 // +10 points per matching field
+    }
+
+    // Bonus if same school type
+    if (school.type === likedSchool.type) {
+      boost += 5
+    }
+  }
+
+  return boost
+}
+
+/**
+ * Rank schools for a student based on profile match + behavioral signals
+ *
+ * @param studentId - The student's ID
+ * @param userProfile - The student's profile (education_branches, education_level, postal_code, etc.)
+ * @param allSchools - All available schools to rank
+ * @returns Schools sorted by relevance to the student (highest match first)
+ */
+export async function rankSchoolsForStudent(
+  studentId: string,
+  userProfile: UserRow,
+  allSchools: SchoolRow[]
+): Promise<SchoolRow[]> {
+  // Load schools the student has already swiped right on
+  const rightSwipedSchools = await getStudentRightSwipedSchools(studentId)
+
+  // Score each school
+  const scoredSchools = allSchools.map((school) => {
+    // Profile match score (0-100)
+    const profileScore = scoreSchoolForStudent(school, userProfile)
+
+    // Behavioral boost from previous swipes (0+)
+    const behavioralBoost = applyBehavioralBoost(school, rightSwipedSchools)
+
+    // Total score = 60% profile match + 40% behavioral boost
+    const totalScore = profileScore * 0.6 + Math.min(behavioralBoost, 40) * 0.4
+
+    return {
+      school,
+      score: totalScore,
+    }
+  })
+
+  // Sort by score (highest first)
+  scoredSchools.sort((a, b) => b.score - a.score)
+
+  // Return just the schools, in ranked order
+  return scoredSchools.map((item) => item.school)
+}


### PR DESCRIPTION
- Create lib/supabase/schoolRanking.ts with ranking algorithm
  * Scores schools by field overlap (60%), education level match (20%), region match (20%)
  * Applies behavioral boost: schools similar to previously swiped schools rank higher
  * Result: students see personalized school deck matching their interests

- Modify lib/supabase/database.ts
  * Add getStudentRightSwipes() helper to load student's previous right-swipes

- Update app/(student)/discover/page.tsx
  * Import and use rankSchoolsForStudent() when loading schools
  * Maintains fallback to default order if user not logged in or profile incomplete
  * Dependency array includes user.id and user.profile for reactivity

This enables students to see schools matching their profile interests first, mimicking Tinder's algorithm that shows users content they're likely to engage with.